### PR TITLE
Fix the `database does not exist` errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         volumes:
             - data:/var/lib/postgresql/data
         healthcheck:
-            test: ["CMD", "pg_isready", "-U", "datacatdbuser"]
+            test: ["CMD", "pg_isready", "-d", "datacatdb", "-U", "datacatdbuser"]
             interval: 10s
             start_period: 30s
     server:


### PR DESCRIPTION
By default, postgresql looks for a database with the same name as the user.
In this case, database name must be explicitly defined.